### PR TITLE
BOSA21Q1-370 Issue when person doesn't exist in Person Services (UAT only)

### DIFF
--- a/lib/extends/verifications_omniauth/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/lib/extends/verifications_omniauth/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -37,6 +37,7 @@ module OmniauthRegistrationFormExtend
     private
 
     def predefined_nickname
+      return "" if raw_data.nil? || raw_data[:info].nil?
       "#{raw_data[:info][:first_name][0]}#{raw_data[:info][:last_name]}"
     end
   end


### PR DESCRIPTION
## Description
- What?
- - Error 500 when person doesn't exist in Person Service
- Why?
- - Answer return by CSAM is nil and the predefined_nickname make an error
- How?
- - Check if the answer is nil

## Ticket
[BOSA21Q1-370](https://belighted.atlassian.net/browse/BOSA21Q1-370?atlOrigin=eyJpIjoiYTI5MjdjYWVhOGYyNDllNTlmMWI3ZTVkYTNkNDczZGUiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [x]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes
