### PR TITLE
Add missing require for virtus

### DIFF
--- a/lib/decidim/verifications_omniauth.rb
+++ b/lib/decidim/verifications_omniauth.rb
@@ -11,6 +11,8 @@
 #
 # Given we do not use mongoid's Boolean lets define it before the mongoid and inherit it from virtus one.
 # Otherwise it breaks all the `attribute :attr_name, Boolean` calls in `decidim` gem (and there are A LOT of them)
+require "virtus"
+
 unless defined?(Boolean)
   class Boolean < Virtus::Attribute::Boolean; end
 end


### PR DESCRIPTION
Hi,
complete ruby noob here, trying to install this decidim plugin, I had a problem:

```shell
$ bundle exec rails decidim_verifications_omniauth:install:migrations
rails aborted!
NameError: uninitialized constant Virtus
/home/decidim/decidim_app/config/application.rb:13:in `<main>'
/home/decidim/decidim_app/Rakefile:4:in `<main>'
bin/rails:5:in `<main>'

Caused by:
LoadError: cannot load such file -- decidim-verifications_omniauth
/home/decidim/decidim_app/config/application.rb:13:in `<main>'
/home/decidim/decidim_app/Rakefile:4:in `<main>'
bin/rails:5:in `<main>'
(See full trace by running task with --trace)
```

Trying to use rails binary gave more informations:

```shell
$ bin/rails --help                                                                                                                                                                
[...]

All commands can be run with -h (or --help) for more information.
In addition to those commands, there are:

/home/decidim/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/bundler/gems/decidim-module-verifications_omniauth-a3695b6b31a8/lib/decidim/verifications_omniauth.rb:15:in `<main>': uninitialized constant Virtus (NameErro
r)
```

Do not hesitate to tell me if the format of the code isn't good, and so for the commit message format.